### PR TITLE
Add support for TTGO T-Display

### DIFF
--- a/DRIVERS.md
+++ b/DRIVERS.md
@@ -32,6 +32,7 @@ access via the `Writer` and `CWriter` classes is documented
   3.1 [Drivers for ST7735R](./DRIVERS.md#31-drivers-for-st7735r) Small TFTs  
   3.2 [Drivers for ILI9341](./DRIVERS.md#32-drivers-for-ili9341) Large TFTs  
   3.3 [Drivers for ST7789](./DRIVERS.md#33-drivers-for-st7789) Small high density TFTs  
+  3.3.1 [TTGO T Display](./DRIVERS.md#331-ttgo-t-display) Low cost ESP32 with integrated display  
  4. [Drivers for sharp displays](./DRIVERS.md#4-drivers-for-sharp-displays) Large low power monochrome displays  
   4.1 [Display characteristics](./DRIVERS.md#41-display-characteristics)  
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;4.1.1 [The VCOM bit](./DRIVERS.md#411-the-vcom-bit)  
@@ -400,14 +401,23 @@ below. An example file for the Pi Pico is in `color_setup/ssd7789.py`.
  * `width=240`
  * `disp_mode=0` By default the display chip operates in landscape mode. This
  arg enables portrait mode and other configurations. See below.
- * `init_spi=False` This optional arg enables flexible options in configuring
- the SPI bus. The default assumes exclusive access to the bus. In this normal
- case, `color_setup.py` initialises it and the settings will be left in place.
- If the bus is shared with devices which require different settings, a callback
- function should be passed. It will be called prior to each SPI bus write. The
- callback will receive a single arg being the SPI bus instance. It will
- typically be a one-liner or lambda initialising the bus. A minimal example is
- this function:
+ * `init_spi=False` For shared SPI bus applications. See note below.
+ * `offset=(0, 0)` This is intended for display hardware where the display
+ hardware's coordinate system is offset relative to the chip's RAM origin. An
+ `(x, y)` tuple (where `x` and `y` are positive integers) can offset this. In
+ practice, when other display hardware is supported, this doc will be amended
+ to specify the values to be used.
+
+### init_spi
+
+This optional arg enables flexible options in configuring the SPI bus. The
+default assumes exclusive access to the bus. In this normal case,
+`color_setup.py` initialises it and the settings will be left in place. If the
+bus is shared with devices which require different settings, a callback
+function should be passed. It will be called prior to each SPI bus write. The
+callback will receive a single arg being the SPI bus instance. It will
+typically be a one-liner or lambda initialising the bus. A minimal example is
+this function:
 ```python
 def spi_init(spi):
     spi.init(baudrate=30_000_000)
@@ -461,6 +471,15 @@ At a 60MHz baudrate this equates to
 240x240x16/6e7=15.36ms  
 This suggests that about 80% of the latency results from the Python code. An
 option may be to overclock.
+
+### 3.3.1 TTGO T Display
+
+This is an ESP32 based device with an integrated 1.14" 135x240 pixel display
+based on ST7789.
+
+It is supported by `color_setup_ttgo.py` in `drivers/st7789`. Copy to
+`/pyboard/color_setup.py` on the device. It produces a landscape mode display
+with the top left hand corner adjacent to pin 36.
 
 ###### [Contents](./DRIVERS.md#contents)
 

--- a/README.md
+++ b/README.md
@@ -202,8 +202,8 @@ code. This stuff is easier than you might think.
 
 # 2. Files and Dependencies
 
-Firmware should be V1.13 or later. At the time of writing the Pi Pico was new:
-firmware should be from a daily build or >=V1.15 when it arrives.
+Firmware should be V1.13 or later. On the Pi Pico firmware should be V1.15 or
+later.
 
 Installation comprises copying the `gui` and `drivers` directories, with their
 contents, plus a hardware configuration file, to the target. The directory

--- a/color_setup/ssd7789_TTGO_T_display.py
+++ b/color_setup/ssd7789_TTGO_T_display.py
@@ -1,0 +1,73 @@
+# color_setup.py Customise for your hardware config
+
+# Released under the MIT License (MIT). See LICENSE.
+# Copyright (c) 2021 Peter Hinch, Ihor Nehrutsa
+
+# Supports:
+# TTGO T-Display 1.14" 135*240(Pixel) with MicroSD - ST7789V
+# http://www.lilygo.cn/claprod_view.aspx?TypeId=62&Id=1274
+# http://www.lilygo.cn/prod_view.aspx?TypeId=50044&Id=1126
+# https://github.com/Xinyuan-LilyGO/TTGO-T-Display
+# https://github.com/Xinyuan-LilyGO/TTGO-T-Display/blob/master/image/pinmap.jpg
+# https://github.com/Xinyuan-LilyGO/TTGO-T-Display/blob/master/schematic/ESP32-TFT(6-26).pdf
+
+# Demo of initialisation procedure designed to minimise risk of memory fail
+# when instantiating the frame buffer. The aim is to do this as early as
+# possible before importing other modules.
+
+# WIRING (TTGO T-Display pin nos and names).
+# Pinout of TFT Driver 
+# ST7789     ESP32
+# TFT_MISO  N/A
+TFT_MOSI =   19
+TFT_SCLK =   18
+TFT_CS =      5
+TFT_DC =     16
+TFT_RST =    23
+TFT_BL =      4  # LEDK = BL Display backlight control pin
+
+ADC_IN =     34
+ADC_EN =     14  # PWR_EN = ADC_EN is the ADC detection enable port
+
+BUTTON1 =    35  # right of the USB connector
+BUTTON2 =     0  # left of the USB connector
+
+#I2C_SDA =    19
+#I2C_SCL =    18
+
+#DAC1 25
+#DAC2 26
+
+# ESP32 chip
+VSPI_ID = 2  # hardware SPI number
+
+from machine import Pin, SPI, ADC
+import gc
+
+from drivers.st7789.st7789_4bit import ST7789 as SSD, PORTRAIT, USD, REFLECT
+
+pdc = Pin(TFT_DC, Pin.OUT, value=0)  # Arbitrary pins
+pcs = Pin(TFT_CS, Pin.OUT, value=1)
+prst = Pin(TFT_RST, Pin.OUT, value=1)
+pbl = Pin(TFT_BL, Pin.OUT, value=1)
+
+gc.collect()  # Precaution before instantiating framebuf
+# Conservative low baudrate. Can go to 62.5MHz.
+spi = SPI(VSPI_ID, 30_000_000, sck=Pin(TFT_SCLK), mosi=Pin(TFT_MOSI))
+ssd = SSD(spi, width=135, height=240, dc=pdc, cs=pcs, rst=prst) #, disp_mode=PORTRAIT | USD) 
+
+# optional
+# b1 = Pin(BUTTON1, Pin.IN)
+# b2 = Pin(BUTTON2, Pin.IN)
+# adc_en = Pin(ADC_EN, Pin.OUT, value=1)
+# adc_in = ADC(Pin(ADC_IN))
+# adc_en.value(0)
+'''
+Set PWR_EN to "1" and read voltage in BAT_ADC, 
+if this voltage more than 4.3 V device have powered from USB. 
+If less then 4.3 V - device have power from battery. 
+To save battery you can set PWR_EN to "0" and in this case the USB converter 
+will be power off and do not use your battery. 
+When you need to measure battery voltage first set PWR_EN to "1", 
+measure voltage and then set PWR_EN back to "0" for save battery.
+'''

--- a/color_setup/ssd7789_TTGO_T_display.py
+++ b/color_setup/ssd7789_TTGO_T_display.py
@@ -4,7 +4,7 @@
 # Copyright (c) 2021 Peter Hinch, Ihor Nehrutsa
 
 # Supports:
-# TTGO T-Display 1.14" 135*240(Pixel) with MicroSD - ST7789V
+# TTGO T-Display 1.14" 135*240(Pixel) based on ST7789V
 # http://www.lilygo.cn/claprod_view.aspx?TypeId=62&Id=1274
 # http://www.lilygo.cn/prod_view.aspx?TypeId=50044&Id=1126
 # https://github.com/Xinyuan-LilyGO/TTGO-T-Display
@@ -38,9 +38,6 @@ BUTTON2 =     0  # left of the USB connector
 #DAC1 25
 #DAC2 26
 
-# ESP32 chip
-VSPI_ID = 2  # hardware SPI number
-
 from machine import Pin, SPI, ADC
 import gc
 
@@ -53,8 +50,10 @@ pbl = Pin(TFT_BL, Pin.OUT, value=1)
 
 gc.collect()  # Precaution before instantiating framebuf
 # Conservative low baudrate. Can go to 62.5MHz.
-spi = SPI(VSPI_ID, 30_000_000, sck=Pin(TFT_SCLK), mosi=Pin(TFT_MOSI))
-ssd = SSD(spi, width=135, height=240, dc=pdc, cs=pcs, rst=prst) #, disp_mode=PORTRAIT | USD) 
+spi = SPI(1, 30_000_000, sck=Pin(TFT_SCLK), mosi=Pin(TFT_MOSI))
+
+#ssd = SSD(spi, height=240, width=135, dc=pdc, cs=pcs, rst=prst) #, disp_mode=PORTRAIT | USD) 
+ssd = SSD(spi, height=(135+5)*2, width=240, dc=pdc, cs=pcs, rst=prst) #, disp_mode=PORTRAIT | USD) 
 
 # optional
 # b1 = Pin(BUTTON1, Pin.IN)

--- a/verify.py
+++ b/verify.py
@@ -1,0 +1,16 @@
+from color_setup import ssd, pbl  # Create a display instance
+from gui.core.colors import RED, BLUE, GREEN, YELLOW, MAGENTA, CYAN, GREY
+from gui.core.nanogui import refresh
+refresh(ssd, True)  # Initialise and clear display.
+# Uncomment for ePaper displays
+# ssd.wait_until_ready()
+ssd.fill(0)
+ssd.line(0, 0, ssd.width - 1, ssd.height - 1, GREEN)  # Green diagonal corner-to-corner
+ssd.line(0, 0, ssd.width - 1, 0, YELLOW)  # Yellow top line from left to right
+ssd.line(0, 0, 0, ssd.height-1, MAGENTA)  # Magenta left line from up to down
+ssd.line(ssd.width//2, 0, ssd.width//2, ssd.height-1, RED)  # Red central line from up to down
+ssd.line(0, ssd.height//2, ssd.width - 1, ssd.height//2, BLUE)  # Blue central line left to right
+ssd.fill_rect(0, 0, ssd.width//2, 41, CYAN)  # Red square at top left
+ssd.fill_rect(0, 0, 53, ssd.height//2, GREY)  # Green square at top left
+ssd.rect(ssd.width -15, ssd.height -15, 15, 15, BLUE)  # Blue square at bottom right
+ssd.show()

--- a/verify.py
+++ b/verify.py
@@ -10,7 +10,9 @@ ssd.line(0, 0, ssd.width - 1, 0, YELLOW)  # Yellow top line from left to right
 ssd.line(0, 0, 0, ssd.height-1, MAGENTA)  # Magenta left line from up to down
 ssd.line(ssd.width//2, 0, ssd.width//2, ssd.height-1, RED)  # Red central line from up to down
 ssd.line(0, ssd.height//2, ssd.width - 1, ssd.height//2, BLUE)  # Blue central line left to right
-ssd.fill_rect(0, 0, ssd.width//2, 41, CYAN)  # Red square at top left
-ssd.fill_rect(0, 0, 53, ssd.height//2, GREY)  # Green square at top left
-ssd.rect(ssd.width -15, ssd.height -15, 15, 15, BLUE)  # Blue square at bottom right
+
+ssd.fill_rect(0, 0, ssd.width//2, 41, CYAN)  # Cyan square at top left
+ssd.fill_rect(0, 0, 53, ssd.height//2, GREY)  # Grey square at top left
+
+#ssd.rect(ssd.width -15, ssd.height -15, 15, 15, BLUE)  # Blue square at bottom right
 ssd.show()


### PR DESCRIPTION
Hello, Peter.
Could you help me?

I try to add support of TTGO T-Display 1.14" 135*240(Pixel) based on ST7789V  
http://www.lilygo.cn/claprod_view.aspx?TypeId=62&Id=1274  
https://github.com/Xinyuan-LilyGO/TTGO-T-Display  
https://github.com/Xinyuan-LilyGO/TTGO-T-Display/blob/master/image/pinmap.jpg  
https://github.com/Xinyuan-LilyGO/TTGO-T-Display/blob/master/schematic/ESP32-TFT(6-26).pdf  

It should work as Adafruit 1.3" and 1.54" 240x240 Wide Angle TFT LCD Display with MicroSD - ST7789  
but not works.  
WIP.

FactoryTest
https://github.com/Xinyuan-LilyGO/TTGO-T-Display/blob/master/TFT_eSPI/examples/FactoryTest/FactoryTest.ino
ST7789 Initialization
https://github.com/Xinyuan-LilyGO/TTGO-T-Display/blob/master/TFT_eSPI/TFT_Drivers/ST7789_Init.h

Thanks.
