### PR TITLE
Correct color names and hexadecimal codes

### DIFF
--- a/gui/core/colors.py
+++ b/gui/core/colors.py
@@ -3,6 +3,9 @@
 # Released under the MIT License (MIT). See LICENSE.
 # Copyright (c) 2020 Peter Hinch
 
+# See color names and hexadecimal codes at
+# https://en.wikipedia.org/wiki/Web_colors
+
 from color_setup import SSD
 
 # Code can be portable between 4-bit and other drivers by calling create_color
@@ -11,38 +14,53 @@ def create_color(idx, r, g, b):
     if not hasattr(SSD, 'lut'):
         return c
     if not 0 <= idx <= 15:
-        raise ValueError('Color nos must be 0..15')
+        raise ValueError('Color numbers must be 0..15')
     x = idx << 1
     SSD.lut[x] = c & 0xff
     SSD.lut[x + 1] = c >> 8
     return idx
 
+# Colors must be safe to convert to RGB565 and RGB444.
+# It is recommended to use numbers 10, 11, 12 to color redefinition by a user.
+
 if hasattr(SSD, 'lut'):  # Colors defined by LUT
     BLACK = create_color(0, 0, 0, 0)
-    GREEN = create_color(1, 0, 255, 0)
-    RED = create_color(2, 255, 0, 0)
-    LIGHTRED = create_color(3, 140, 0, 0)
-    BLUE = create_color(4, 0, 0, 255)
-    YELLOW = create_color(5, 255, 255, 0)
-    GREY = create_color(6, 100, 100, 100)
-    MAGENTA = create_color(7, 255, 0, 255)
-    CYAN = create_color(8, 0, 255, 255)
-    LIGHTGREEN = create_color(9, 0, 100, 0)
-    DARKGREEN = create_color(10, 0, 80, 0)
-    DARKBLUE = create_color(11, 0, 0, 90)
-    # 12, 13, 14 free for user definition
+    RED = create_color(1, 255, 0, 0)  # pure colors
+    GREEN = create_color(2, 0, 255, 0)
+    BLUE = create_color(3, 0, 0, 255)
+    DARKTRED = create_color(4, 0x80, 0, 0)  # dark pure colors
+    DARKGREEN = create_color(5, 0, 0x80, 0)
+    DARKBLUE = create_color(6, 0, 0, 0x80)
+    CYAN = create_color(7, 0, 255, 255)  # composite colors
+    MAGENTA = create_color(8, 255, 0, 255)
+    YELLOW = create_color(9, 255, 255, 0)
+    DARKCYAN = create_color(10, 0, 0x80, 0x80)  # dark composite colors
+    DARKMAGENTA = create_color(11, 0x80, 0, 0x80)
+    BROWN = create_color(12, 0x80, 0x80, 0)
+    GREY = create_color(13, 0x80, 0x80, 0x80)  # gray colors
+    SILVER = create_color(14, 0xC0, 0xC0, 0xC0)
     WHITE = create_color(15, 255, 255, 255)
 else:
     BLACK = SSD.rgb(0, 0, 0)
     GREEN = SSD.rgb(0, 255, 0)
     RED = SSD.rgb(255, 0, 0)
-    LIGHTRED = SSD.rgb(140, 0, 0)
+    LIGHTRED = SSD.rgb(140, 0, 0)  # actually darker than red !!!
     BLUE = SSD.rgb(0, 0, 255)
     YELLOW = SSD.rgb(255, 255, 0)
     GREY = SSD.rgb(100, 100, 100)
     MAGENTA = SSD.rgb(255, 0, 255)
     CYAN = SSD.rgb(0, 255, 255)
-    LIGHTGREEN = SSD.rgb(0, 100, 0)
+    LIGHTGREEN = SSD.rgb(0, 100, 0)  # actually darker than green !!!
     DARKGREEN = SSD.rgb(0, 80, 0)
     DARKBLUE = SSD.rgb(0, 0, 90)
     WHITE = SSD.rgb(255, 255, 255)
+
+# Some synonyms of colors
+LIME = GREEN
+AQUA = CYAN
+FUCKSIA = MAGENTA
+MAROON = DARKTRED
+NAVY = DARKBLUE
+TEAL = DARKCYAN
+PURPLE = DARKMAGENTA
+OLIVE = BROWN

--- a/gui/demos/check_colors.py
+++ b/gui/demos/check_colors.py
@@ -1,0 +1,20 @@
+from color_setup import ssd  # Create a display instance
+from gui.core.colors import *
+from gui.core.nanogui import refresh
+
+refresh(ssd, True)  # Initialise and clear display.
+# Uncomment for ePaper displays
+# ssd.wait_until_ready()
+# ssd.fill(0)
+
+# Fill the display with stripes of all colors
+COLORS = 16
+dh = ssd.height // COLORS
+dw = ssd.width // COLORS
+for c in range(0, COLORS):
+    h = dh * c
+    w = dw * c
+    ssd.fill_rect(w, 0, w + dw, ssd.height - 1, c)  
+    #ssd.fill_rect(0, h, ssd.width - 1, h + dh, c)  
+
+ssd.show()


### PR DESCRIPTION
Hello, Peter.
I propose to correct the color names and hex codes according to base colors from
https://en.wikipedia.org/wiki/Web_colors

I think all hardware manufacturers are guided by these hex values.
Also, some used color codes are unsafe if RGB565 or RGB444 converting used.
100=0x64  and   90=0x5A will lose the lowest bits when converting to RGB565 or RGB444.

I am not sure about the synonyms of colors. Probably they are not needed.

I haven't changed yet the else part of color definitions.

This pull request leads to some corrections in documentation and code due to the change in user colors.

Also, I propose to develop several color schemes similar to those used in editors with good contrast and readable.
![image](https://user-images.githubusercontent.com/48811061/115955857-ed512300-a501-11eb-811f-f2828146b8a8.png)

I want to know your opinion on the main.
WIP
