### PR TITLE
Added text alignment to the Label widget

### DIFF
--- a/gui/widgets/label.py
+++ b/gui/widgets/label.py
@@ -3,12 +3,13 @@
 # Released under the MIT License (MIT). See LICENSE.
 # Copyright (c) 2018-2020 Peter Hinch
 
+from micropython import const
 from gui.core.nanogui import DObject
 from gui.core.writer import Writer
 
-ALIGN_LEFT = 0
-ALIGN_RIGHT = 1
-ALIGN_CENTER = 2
+ALIGN_LEFT = const(0)
+ALIGN_RIGHT = const(1)
+ALIGN_CENTER = const(2)
 
 # text: str display string int save width
 class Label(DObject):
@@ -45,16 +46,16 @@ class Label(DObject):
         wri = self.writer
         dev = self.device
         if self.align == ALIGN_LEFT:
-          Writer.set_textpos(dev, self.row, self.col)
-        else:
-          txt_width = wri.stringlen(txt)
-          if self.width <= txt_width:
             Writer.set_textpos(dev, self.row, self.col)
-          else:
-            if self.align == ALIGN_RIGHT:
-              Writer.set_textpos(dev, self.row, self.col + self.width - txt_width)
+        else:
+            txt_width = wri.stringlen(txt)
+            if self.width <= txt_width:
+                Writer.set_textpos(dev, self.row, self.col)
             else:
-              Writer.set_textpos(dev, self.row, self.col + self.width // 2 - txt_width // 2)
+                if self.align == ALIGN_RIGHT:
+                    Writer.set_textpos(dev, self.row, self.col + self.width - txt_width)
+                else:
+                    Writer.set_textpos(dev, self.row, self.col + self.width // 2 - txt_width // 2)
         wri.setcolor(self.fgcolor, self.bgcolor)
         wri.printstring(txt, self.invert)
         wri.setcolor()  # Restore defaults

--- a/gui/widgets/label.py
+++ b/gui/widgets/label.py
@@ -6,9 +6,13 @@
 from gui.core.nanogui import DObject
 from gui.core.writer import Writer
 
+ALIGN_LEFT = 0
+ALIGN_RIGHT = 1
+ALIGN_CENTER = 2
+
 # text: str display string int save width
 class Label(DObject):
-    def __init__(self, writer, row, col, text, invert=False, fgcolor=None, bgcolor=None, bdcolor=False):
+    def __init__(self, writer, row, col, text, invert=False, fgcolor=None, bgcolor=None, bdcolor=False, align=ALIGN_LEFT):
         # Determine width of object
         if isinstance(text, int):
             width = text
@@ -17,6 +21,7 @@ class Label(DObject):
             width = writer.stringlen(text)
         height = writer.height
         super().__init__(writer, row, col, height, width, fgcolor, bgcolor, bdcolor)
+        self.align = align
         if text is not None:
             self.value(text, invert)
 
@@ -39,7 +44,17 @@ class Label(DObject):
         super().show()  # Draw or erase border
         wri = self.writer
         dev = self.device
-        Writer.set_textpos(dev, self.row, self.col)
+        if self.align == ALIGN_LEFT:
+          Writer.set_textpos(dev, self.row, self.col)
+        else:
+          txt_width = wri.stringlen(txt)
+          if self.width <= txt_width:
+            Writer.set_textpos(dev, self.row, self.col)
+          else:
+            if self.align == ALIGN_RIGHT:
+              Writer.set_textpos(dev, self.row, self.col + self.width - txt_width)
+            else:
+              Writer.set_textpos(dev, self.row, self.col + self.width // 2 - txt_width // 2)
         wri.setcolor(self.fgcolor, self.bgcolor)
         wri.printstring(txt, self.invert)
         wri.setcolor()  # Restore defaults


### PR DESCRIPTION
I've added a new argument to the constructor of the Label widget. It allows aligning of the text inside the label to left (as it is now), right or center. If the text is wider than the label, the argument is ignored.