### PR TITLE
add sh1106 driver and update docs and create config sample

### DIFF
--- a/DISPLAYS.md
+++ b/DISPLAYS.md
@@ -48,6 +48,13 @@ I2C or SPI interfaces. An example is [Adafruit 938][4m]. The SSD1306 driver in
 this repo has a minor addition to enable it to support demos intended for color
 displays.
 
+Monochrome OLED displays based on the SH1106 chip are supported via the
+[unofficial driver](https://github.com/robert-hh/SH1106).
+Displays are available from various sources and can use I2C or SPI interfaces.
+An exmaple is the [Inland IIC SPI 1.3" 128x64 OLED V2.0](https://www.microcenter.com/product/643965/inland-iic-spi-13-128x64-oled-v20-graphic-display-module-for-arduino-uno-r3)
+AKA [KeyStudio](https://wiki.keyestudio.com/Ks0056_keyestudio_1.3%22_128x64_OLED_Graphic_Display).
+
+
 Nokia 5110 (PCD8544) displays. [This driver](https://github.com/mcauser/micropython-pcd8544.git)
 is compatible.
 

--- a/drivers/sh1106/sh1106.py
+++ b/drivers/sh1106/sh1106.py
@@ -75,6 +75,7 @@
 from micropython import const
 import utime as time
 import framebuf
+from drivers.boolpalette import BoolPalette
 
 
 # a few register definitions
@@ -106,18 +107,19 @@ class SH1106(framebuf.FrameBuffer):
         self.pages_to_update = 0
 
         if self.rotate90:
+            # decouple renderbuf and displaybuf
             self.displaybuf = bytearray(self.bufsize)
             # HMSB is required to keep the bit order in the render buffer
             # compatible with byte-for-byte remapping to the display buffer,
             # which is in VLSB. Else we'd have to copy bit-by-bit!
-            super().__init__(
-                self.renderbuf, self.height, self.width, framebuf.MONO_HMSB
-            )
+            mode = framebuf.MONO_HMSB
+            self.palette = BoolPalette(mode)
+            super().__init__(self.renderbuf, self.height, self.width, mode)
         else:
             self.displaybuf = self.renderbuf
-            super().__init__(
-                self.renderbuf, self.width, self.height, framebuf.MONO_VLSB
-            )
+            mode = framebuf.MONO_VLSB
+            self.palette = BoolPalette(mode)
+            super().__init__(self.renderbuf, self.width, self.height, mode)
 
         # flip() was called rotate() once, provide backwards compatibility.
         self.rotate = self.flip

--- a/drivers/sh1106/sh1106.py
+++ b/drivers/sh1106/sh1106.py
@@ -1,0 +1,330 @@
+# Copied from https://github.com/robert-hh/SH1106
+#
+# MicroPython SH1106 OLED driver, I2C and SPI interfaces
+#
+# The MIT License (MIT)
+#
+# Copyright (c) 2016 Radomir Dopieralski (@deshipu),
+#               2017-2021 Robert Hammelrath (@robert-hh)
+#               2021 Tim Weber (@scy)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# Sample code sections for ESP8266 pin assignments
+# ------------ SPI ------------------
+# Pin Map SPI
+#   - 3v - xxxxxx   - Vcc
+#   - G  - xxxxxx   - Gnd
+#   - D7 - GPIO 13  - Din / MOSI fixed
+#   - D5 - GPIO 14  - Clk / Sck fixed
+#   - D8 - GPIO 4   - CS (optional, if the only connected device)
+#   - D2 - GPIO 5   - D/C
+#   - D1 - GPIO 2   - Res
+#
+# for CS, D/C and Res other ports may be chosen.
+#
+# from machine import Pin, SPI
+# import sh1106
+
+# spi = SPI(1, baudrate=1000000)
+# display = sh1106.SH1106_SPI(128, 64, spi, Pin(5), Pin(2), Pin(4))
+# display.sleep(False)
+# display.fill(0)
+# display.text('Testing 1', 0, 0, 1)
+# display.show()
+#
+# --------------- I2C ------------------
+#
+# Pin Map I2C
+#   - 3v - xxxxxx   - Vcc
+#   - G  - xxxxxx   - Gnd
+#   - D2 - GPIO 5   - SCK / SCL
+#   - D1 - GPIO 4   - DIN / SDA
+#   - D0 - GPIO 16  - Res
+#   - G  - xxxxxx     CS
+#   - G  - xxxxxx     D/C
+#
+# Pin's for I2C can be set almost arbitrary
+#
+# from machine import Pin, I2C
+# import sh1106
+#
+# i2c = I2C(scl=Pin(5), sda=Pin(4), freq=400000)
+# display = sh1106.SH1106_I2C(128, 64, i2c, Pin(16), 0x3c)
+# display.sleep(False)
+# display.fill(0)
+# display.text('Testing 1', 0, 0, 1)
+# display.show()
+
+from micropython import const
+import utime as time
+import framebuf
+
+
+# a few register definitions
+_SET_CONTRAST = const(0x81)
+_SET_NORM_INV = const(0xA6)
+_SET_DISP = const(0xAE)
+_SET_SCAN_DIR = const(0xC0)
+_SET_SEG_REMAP = const(0xA0)
+_LOW_COLUMN_ADDRESS = const(0x00)
+_HIGH_COLUMN_ADDRESS = const(0x10)
+_SET_PAGE_ADDRESS = const(0xB0)
+
+# Subclassing FrameBuffer provides support for graphics primitives
+# http://docs.micropython.org/en/latest/pyboard/library/framebuf.html
+class SH1106(framebuf.FrameBuffer):
+    @staticmethod
+    def rgb(r, g, b):
+        return int((r > 127) or (g > 127) or (b > 127))
+
+    def __init__(self, width, height, external_vcc, rotate=0):
+        self.width = width
+        self.height = height
+        self.external_vcc = external_vcc
+        self.flip_en = rotate == 180 or rotate == 270
+        self.rotate90 = rotate == 90 or rotate == 270
+        self.pages = self.height // 8
+        self.bufsize = self.pages * self.width
+        self.renderbuf = bytearray(self.bufsize)
+        self.pages_to_update = 0
+
+        if self.rotate90:
+            self.displaybuf = bytearray(self.bufsize)
+            # HMSB is required to keep the bit order in the render buffer
+            # compatible with byte-for-byte remapping to the display buffer,
+            # which is in VLSB. Else we'd have to copy bit-by-bit!
+            super().__init__(
+                self.renderbuf, self.height, self.width, framebuf.MONO_HMSB
+            )
+        else:
+            self.displaybuf = self.renderbuf
+            super().__init__(
+                self.renderbuf, self.width, self.height, framebuf.MONO_VLSB
+            )
+
+        # flip() was called rotate() once, provide backwards compatibility.
+        self.rotate = self.flip
+        self.init_display()
+
+    def init_display(self):
+        self.reset()
+        self.fill(0)
+        self.show()
+        self.poweron()
+        # rotate90 requires a call to flip() for setting up.
+        self.flip(self.flip_en)
+
+    def poweroff(self):
+        self.write_cmd(_SET_DISP | 0x00)
+
+    def poweron(self):
+        self.write_cmd(_SET_DISP | 0x01)
+        if self.delay:
+            time.sleep_ms(self.delay)
+
+    def flip(self, flag=None, update=True):
+        if flag is None:
+            flag = not self.flip_en
+        mir_v = flag ^ self.rotate90
+        mir_h = flag
+        self.write_cmd(_SET_SEG_REMAP | (0x01 if mir_v else 0x00))
+        self.write_cmd(_SET_SCAN_DIR | (0x08 if mir_h else 0x00))
+        self.flip_en = flag
+        if update:
+            self.show(True)  # full update
+
+    def sleep(self, value):
+        self.write_cmd(_SET_DISP | (not value))
+
+    def contrast(self, contrast):
+        self.write_cmd(_SET_CONTRAST)
+        self.write_cmd(contrast)
+
+    def invert(self, invert):
+        self.write_cmd(_SET_NORM_INV | (invert & 1))
+
+    def show(self, full_update=False):
+        # self.* lookups in loops take significant time (~4fps).
+        (w, p, db, rb) = (self.width, self.pages, self.displaybuf, self.renderbuf)
+        if self.rotate90:
+            for i in range(self.bufsize):
+                db[w * (i % p) + (i // p)] = rb[i]
+        if full_update:
+            pages_to_update = (1 << self.pages) - 1
+        else:
+            pages_to_update = self.pages_to_update
+        # print("Updating pages: {:08b}".format(pages_to_update))
+        for page in range(self.pages):
+            if pages_to_update & (1 << page):
+                self.write_cmd(_SET_PAGE_ADDRESS | page)
+                self.write_cmd(_LOW_COLUMN_ADDRESS | 2)
+                self.write_cmd(_HIGH_COLUMN_ADDRESS | 0)
+                self.write_data(db[(w * page) : (w * page + w)])
+        self.pages_to_update = 0
+
+    def pixel(self, x, y, color=None):
+        if color is None:
+            return super().pixel(x, y)
+        else:
+            super().pixel(x, y, color)
+            page = y // 8
+            self.pages_to_update |= 1 << page
+
+    def text(self, text, x, y, color=1):
+        super().text(text, x, y, color)
+        self.register_updates(y, y + 7)
+
+    def line(self, x0, y0, x1, y1, color):
+        super().line(x0, y0, x1, y1, color)
+        self.register_updates(y0, y1)
+
+    def hline(self, x, y, w, color):
+        super().hline(x, y, w, color)
+        self.register_updates(y)
+
+    def vline(self, x, y, h, color):
+        super().vline(x, y, h, color)
+        self.register_updates(y, y + h - 1)
+
+    def fill(self, color):
+        super().fill(color)
+        self.pages_to_update = (1 << self.pages) - 1
+
+    def blit(self, fbuf, x, y, key=-1, palette=None):
+        super().blit(fbuf, x, y, key, palette)
+        self.register_updates(y, y + self.height)
+
+    def scroll(self, x, y):
+        # my understanding is that scroll() does a full screen change
+        super().scroll(x, y)
+        self.pages_to_update = (1 << self.pages) - 1
+
+    def fill_rect(self, x, y, w, h, color):
+        super().fill_rect(x, y, w, h, color)
+        self.register_updates(y, y + h - 1)
+
+    def rect(self, x, y, w, h, color):
+        super().rect(x, y, w, h, color)
+        self.register_updates(y, y + h - 1)
+
+    def register_updates(self, y0, y1=None):
+        # this function takes the top and optional bottom address of the changes made
+        # and updates the pages_to_change list with any changed pages
+        # that are not yet on the list
+        start_page = max(0, y0 // 8)
+        end_page = max(0, y1 // 8) if y1 is not None else start_page
+        # rearrange start_page and end_page if coordinates were given from bottom to top
+        if start_page > end_page:
+            start_page, end_page = end_page, start_page
+        for page in range(start_page, end_page + 1):
+            self.pages_to_update |= 1 << page
+
+    def reset(self, res):
+        if res is not None:
+            res(1)
+            time.sleep_ms(1)
+            res(0)
+            time.sleep_ms(20)
+            res(1)
+            time.sleep_ms(20)
+
+
+class SH1106_I2C(SH1106):
+    def __init__(
+        self,
+        width,
+        height,
+        i2c,
+        res=None,
+        addr=0x3C,
+        rotate=0,
+        external_vcc=False,
+        delay=0,
+    ):
+        self.i2c = i2c
+        self.addr = addr
+        self.res = res
+        self.temp = bytearray(2)
+        self.delay = delay
+        if res is not None:
+            res.init(res.OUT, value=1)
+        super().__init__(width, height, external_vcc, rotate)
+
+    def write_cmd(self, cmd):
+        self.temp[0] = 0x80  # Co=1, D/C#=0
+        self.temp[1] = cmd
+        self.i2c.writeto(self.addr, self.temp)
+
+    def write_data(self, buf):
+        self.i2c.writeto(self.addr, b"\x40" + buf)
+
+    def reset(self):
+        super().reset(self.res)
+
+
+class SH1106_SPI(SH1106):
+    def __init__(
+        self,
+        width,
+        height,
+        spi,
+        dc,
+        res=None,
+        cs=None,
+        rotate=0,
+        external_vcc=False,
+        delay=0,
+    ):
+        dc.init(dc.OUT, value=0)
+        if res is not None:
+            res.init(res.OUT, value=0)
+        if cs is not None:
+            cs.init(cs.OUT, value=1)
+        self.spi = spi
+        self.dc = dc
+        self.res = res
+        self.cs = cs
+        self.delay = delay
+        super().__init__(width, height, external_vcc, rotate)
+
+    def write_cmd(self, cmd):
+        if self.cs is not None:
+            self.cs(1)
+            self.dc(0)
+            self.cs(0)
+            self.spi.write(bytearray([cmd]))
+            self.cs(1)
+        else:
+            self.dc(0)
+            self.spi.write(bytearray([cmd]))
+
+    def write_data(self, buf):
+        if self.cs is not None:
+            self.cs(1)
+            self.dc(1)
+            self.cs(0)
+            self.spi.write(buf)
+            self.cs(1)
+        else:
+            self.dc(1)
+            self.spi.write(buf)
+
+    def reset(self):
+        super().reset(self.res)

--- a/setup_examples/sh1106_spi_pico.py
+++ b/setup_examples/sh1106_spi_pico.py
@@ -1,0 +1,15 @@
+from machine import Pin, SPI
+
+from drivers.sh1106.sh1106 import SH1106_SPI as SSD
+
+oled_width = 128
+oled_height = 64
+# Incorporating the Pico pin names into the variable names
+sck_clk = Pin(14)
+tx_mosi = Pin(15)
+rx_miso_dc = Pin(12)
+csn_cs = Pin(13)
+
+oled_spi = SPI(1, sck=sck_clk, mosi=tx_mosi, miso=rx_miso_dc)
+
+ssd = SSD(oled_width, oled_height, oled_spi, dc=rx_miso_dc, cs=csn_cs)


### PR DESCRIPTION
Adding sh driver from https://github.com/robert-hh/SH1106 along with sample program and doc updates. Passes the monochrome tests.

This is based on the monochrome driver similar to the ssd1306. 

* Trailing spaces aren't required in the README for lists (bullet or numbered).  It would be great if the README file didn't rely on 2 trailing spaces on some lines for formatting.
* Tested with the monochrome samples - looks good
* The rgb settings were copied from the SSD1306 driver but I don't know if they are correct.

**Note**
The SH1106 driver fails when called from color examples.  There is a commit note on the SSD1306 that says it was made compatible with color (as gray scale) but I dont' understand how that works. I implemented the same rgb() function but the cwriter fails.