### PR TITLE
Add QR Code Widget for nano-gui

### DIFF
--- a/gui/widgets/qrcode.py
+++ b/gui/widgets/qrcode.py
@@ -1,0 +1,85 @@
+# qrcode.py Test/demo of QRcode widget for nano-gui
+
+# Released under the MIT License (MIT). See LICENSE.
+# Copyright (c) 2024 Machally
+
+# Usage:
+# import gui.demos.qrcode
+
+# Initialise hardware and framebuf before importing modules.
+from framebuf import FrameBuffer, MONO_HLSB
+from gui.core.nanogui import DObject
+from gui.core.colors import *
+from gui.core.writer import Writer
+from uQR import QRCode
+
+class QRCodeWidget(DObject):
+    @staticmethod
+    def len_side(version):
+        return 4 * version + 17
+
+    @staticmethod
+    def make_buffer(version, scale):
+        side = QRCodeWidget.len_side(version) * scale
+        width = (side >> 3) + int(side & 7 > 0)  # Width in bytes
+        return bytearray(side * width)
+
+    def __init__(self, writer, row, col, version=4, scale=1, *, bdcolor=RED, fgcolor=None, bgcolor=WHITE, buf=None):
+        self._version = version
+        self._scale = scale
+        self._iside = self.len_side(version)  # Dimension of unscaled QR image
+        side = self._iside * scale
+        border = 4 * scale
+        wside = side + 2 * border  # Widget dimension
+
+        super().__init__(
+            writer,
+            row,
+            col,
+            wside,
+            wside,
+            fgcolor=fgcolor,
+            bgcolor=bgcolor,
+            bdcolor=bdcolor,
+        )
+
+        self._irow = row + border
+        self._icol = col + border
+        self._qr = QRCode(version, border=0)
+
+        if buf is None:
+            buf = QRCodeWidget.make_buffer(version, scale)
+        self._fb = FrameBuffer(buf, side, side, MONO_HLSB)
+
+    def value(self, data=None):
+        if data is not None:
+            self._update_qr(data)
+
+    def _update_qr(self, data):
+        qr = self._qr
+        qr.clear()
+        qr.add_data(data)
+        matrix = qr.get_matrix()
+        
+        
+        if qr.version != self._version:
+            raise ValueError("Data too long for QR version.")
+
+        wd = self._iside
+        s = self._scale
+
+        for row in range(wd):
+            for col in range(wd):
+                v = matrix[row][col]              
+                for nc in range(s):
+                    for nr in range(s):
+                        self._fb.pixel(col * s + nc, row * s + nr, v)
+
+    def show(self):
+        dev = self.device
+        super().show()  # Desenha a borda primeiro (se necessário)
+        palette = dev.palette
+        palette.bg(self.bgcolor)
+        palette.fg(self.fgcolor)
+        dev.blit(self._fb, self._icol, self._irow, -1, palette)
+


### PR DESCRIPTION
### Description
This pull request introduces a new `QRCodeWidget` for the `nano-gui` library. It provides an interface to render QR codes using the `uQR` library. The widget supports customization of foreground, background, and border colors.

### Features
- Supports custom QR code versions and scaling.
- Compatible with the `nano-gui` framework.
- Allows dynamic updates of QR code content via the `value` method.

### Example Usage
```python
from color_setup import ssd 
from gui.core.nanogui import refresh
from gui.core.writer import CWriter
from gui.core.colors import *
import gui.fonts.arial10 as arial10 
from qrcode import QRCodeWidget

qrcode_args = {
    "version": 6,
    "scale": 3,
    "fgcolor": BLACK,
    "bdcolor": RED,
    "bgcolor": WHITE,  # Garantir fundo branco
}

refresh(ssd, True)
CWriter.set_textpos(ssd, 0, 0)
wri = CWriter(ssd, arial10, WHITE, BLACK, verbose=False)
wri.set_clip(True, True, False)
qr = QRCodeWidget(wri, 10, 10, **qrcode_args)
qr.value("https://example.com")
qr.show()
refresh(ssd)
```
### Testing
The widget has been tested with a demo script, and it renders QR codes correctly with custom colors and sizes.

### License
This contribution is provided under the MIT license.