### PR TITLE
Support CYD2 - ili9341 esp32 2432S028r with 2 USB ports #86

### DIFF
--- a/drivers/ili93xx/ili9341.py
+++ b/drivers/ili93xx/ili9341.py
@@ -53,7 +53,7 @@ class ILI9341(framebuf.FrameBuffer):
         return (r & 0xF8) | (g & 0xE0) >> 5 | (g & 0x1C) << 11 | (b & 0xF8) << 5
 
     # Transpose width & height for landscape mode
-    def __init__(self, spi, cs, dc, rst, height=240, width=320, usd=False, init_spi=False):
+    def __init__(self, spi, cs, dc, rst, height=240, width=320, usd=False, init_spi=False, rotated=False):
         """For more information see
         https://github.com/peterhinch/micropython-nano-gui/blob/master/DRIVERS.md#32-drivers-for-ili9341
         """
@@ -95,7 +95,7 @@ class ILI9341(framebuf.FrameBuffer):
         self._wcd(b"\xc5", b"\x3E\x28")  # VMCTR1 VCOM ctrl 1
         self._wcd(b"\xc7", b"\x86")  # VMCTR2 VCOM ctrl 2
         # (b'\x88', b'\xe8', b'\x48', b'\x28')[rotation // 90]
-        if self.height > self.width:
+        if not rotated:
             self._wcd(b"\x36", b"\x48" if usd else b"\x88")  # MADCTL: RGB portrait mode
         else:
             self._wcd(b"\x36", b"\x28" if usd else b"\xe8")  # MADCTL: RGB landscape mode

--- a/drivers/ili93xx/ili9341_8bit.py
+++ b/drivers/ili93xx/ili9341_8bit.py
@@ -41,7 +41,7 @@ class ILI9341(framebuf.FrameBuffer):
         return (r & 0xE0) | ((g >> 3) & 0x1C) | (b >> 6)
 
     # Transpose width & height for landscape mode
-    def __init__(self, spi, cs, dc, rst, height=240, width=320, usd=False, init_spi=False):
+    def __init__(self, spi, cs, dc, rst, height=240, width=320, usd=False, init_spi=False, rotated=False):
         """For more information see
         https://github.com/peterhinch/micropython-nano-gui/blob/master/DRIVERS.md#32-drivers-for-ili9341
         """
@@ -82,7 +82,7 @@ class ILI9341(framebuf.FrameBuffer):
         self._wcd(b"\xc5", b"\x3E\x28")  # VMCTR1 VCOM ctrl 1
         self._wcd(b"\xc7", b"\x86")  # VMCTR2 VCOM ctrl 2
         # (b'\x88', b'\xe8', b'\x48', b'\x28')[rotation // 90]
-        if height > width:
+        if not rotated:
             self._wcd(b"\x36", b"\x48" if usd else b"\x88")  # MADCTL: RGB portrait mode
         else:
             self._wcd(b"\x36", b"\x28" if usd else b"\xe8")  # MADCTL: RGB landscape mode


### PR DESCRIPTION
NOTE color_setup.py needs adjusting for CYD2, need to switch width/height and rotated compared with CYD1.
Alternatively use ili9341 driver, set width and height to 320x240 and mirror=True.